### PR TITLE
Update to rust 1.43.0, openssl 1.1.1g

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN cd /tmp && LIBLZMA_VERSION=5.2.5 && \
     make install
 
 # -DOPENSSL_NO_SECURE_MEMORY needed due to https://github.com/openssl/openssl/issues/7207
-RUN cd /tmp && OPENSSL_VERSION=1.1.1e && \
+RUN cd /tmp && OPENSSL_VERSION=1.1.1g && \
     curl -LO "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" && \
     tar xf "openssl-$OPENSSL_VERSION.tar.gz" && cd "openssl-$OPENSSL_VERSION" && \
     env CC=musl-gcc ./Configure \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE=fredrikfornwall/rust-static-builder
-STABLE_VERSION=1.42.0
+STABLE_VERSION=1.43.0
 CURRENT_DATE:=$(shell date "+%Y-%m-%d")
 
 build-stable:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ From inside your project directoring containing a `Cargo.toml` file:
 
 ```sh
 # Stable release channel:
-docker run -v "$PWD":/build fredrikfornwall/rust-static-builder:1.41.0
+docker run -v "$PWD":/build fredrikfornwall/rust-static-builder:1.43.0
 
 # Nightly release channel:
 docker run -v "$PWD":/build fredrikfornwall/rust-static-builder-nightly:2020-02-16
@@ -26,7 +26,7 @@ docker run \
        -v "$PWD":/build \
        -v $HOME/.cargo/git:/root/.cargo/git \
        -v $HOME/.cargo/registry:/root/.cargo/registry \
-       fredrikfornwall/rust-static-builder:1.41.0
+       fredrikfornwall/rust-static-builder:1.43.0
 ```
 
 ## Testing
@@ -38,7 +38,7 @@ docker run \
        -v $HOME/.cargo/git:/root/.cargo/git \
        -v $HOME/.cargo/registry:/root/.cargo/registry \
        --entrypoint cargo \
-       fredrikfornwall/rust-static-builder:1.41.0 \
+       fredrikfornwall/rust-static-builder:1.43.0 \
        test --target x86_64-unknown-linux-musl
 ```
 
@@ -49,7 +49,7 @@ By default the built binary will be stripped. Run with `-e NOSTRIP=1`, as in
 docker run \
        -e NOSTRIP=1 \
        -v "$PWD":/build \
-       fredrikfornwall/rust-static-builder:1.41.0
+       fredrikfornwall/rust-static-builder:1.43.0
 ```
 
 to disable stripping.


### PR DESCRIPTION
Related [CVE-2020-1967](https://www.openssl.org/news/secadv/20200421.txt)

> Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the "signature_algorithms_cert" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. 